### PR TITLE
Caching issue

### DIFF
--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
@@ -74,14 +74,14 @@
             var registry = dependency.resolve("epi.storeregistry");
 
             var instantTemplatesStore = registry.get("instanttemplates");
-            console.log(this.contentLink)
-            console.log(that.contentLink)
-            dojo.when(instantTemplatesStore.get(that.contentLink), function (response) {
-                array.forEach(response, function (contentData) {
-                    var child = new ContentType({ contentData: contentData });
-                    this.connect(child, "onSelect", this.onSelect);
-                    this.addChild(child);
-                }, that);
+            dojo.when(instantTemplatesStore.refresh(that.contentLink), function(){
+                dojo.when(instantTemplatesStore.get(that.contentLink), function (response) {
+                    array.forEach(response, function (contentData) {
+                        var child = new ContentType({ contentData: contentData });
+                        that.connect(child, "onSelect", that.onSelect);
+                        that.addChild(child);
+                    }, that);
+                });
             });
         },
 
@@ -114,7 +114,7 @@
             //		callback
 
             topic.publish("/epi/shell/action/changeview", "instantTemplates/CreateContentView", null, {
-                parent: this.parentLink,
+                parent: this.contentLink,
                 contentLink: item.contentLink,
                 headingText: "New Instant Template",
                 templateName: item.name

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
@@ -74,8 +74,9 @@
             var registry = dependency.resolve("epi.storeregistry");
 
             var instantTemplatesStore = registry.get("instanttemplates");
-
-            dojo.when(instantTemplatesStore.get(that.parentLink), function (response) {
+            console.log(this.contentLink)
+            console.log(that.contentLink)
+            dojo.when(instantTemplatesStore.get(that.contentLink), function (response) {
                 array.forEach(response, function (contentData) {
                     var child = new ContentType({ contentData: contentData });
                     this.connect(child, "onSelect", this.onSelect);
@@ -141,6 +142,6 @@
                 this.contentDataStore = registry.get("epi.cms.content.light");
             }
             return this.contentDataStore;
-        },
+        }
     });
 });

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
@@ -54,18 +54,38 @@ function (
         // contentLink: [public] String
         //     The contentlink for which the list will be filtered on.
         contentLink: null,
-
         templatesRoot: null,
+        constructor: function(){
+            var vm = this;
+            topic.subscribe("/epi/shell/action/changeview", function (name, args) {
+                if (name !== "instantTemplates/ContentTypeList") return;
+                vm.contentLink = args.contentLink;
+                vm.render();
+            });
+        },
+        postCreate: function(){
+            this.render();
+        },
+        clear: function(){
+            // summary:
+            //		Destroys the current view.
+            // tags:
+            //		public
 
-        buildRendering: function () {
+            array.forEach(this.getChildren(), function (child) {
+                this.removeChild(child);
+                child.destroyRecursive();
+            }, this);
+        },
+        render: function () {
             // summary:
             //      Construct the base UI with suggested content types.
             // tags:
             //      protected
-
             this.inherited(arguments);
+            this.clear();
 
-            var suggested = new ContentTypeGroup({templatesRoot: this.templatesRoot, parentLink: this.parentLink});
+            var suggested = new ContentTypeGroup({ templatesRoot: this.templatesRoot, contentLink: this.contentLink });
 
             domClass.add(suggested.titleNode, "epi-ribbonHeaderSpecial");
             suggested.set("title", "Available Instant Templates");
@@ -75,7 +95,7 @@ function (
             this._suggestedContentTypes = suggested;
 
             this.set("shouldSkipContentTypeSelection", false);
-        },
+        }
     });
 
 });

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
@@ -60,6 +60,7 @@ function (
             topic.subscribe("/epi/shell/action/changeview", function (name, args) {
                 if (name !== "instantTemplates/ContentTypeList") return;
                 vm.contentLink = args.contentLink;
+                vm.parentLink = args.parentLink;
                 vm.render();
             });
         },

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentSelectionCommand.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentSelectionCommand.js
@@ -20,10 +20,9 @@
 
         _execute: function () {
             var selectionData = this.get("selectionData");
-
             topic.publish("/epi/shell/action/changeview", "instantTemplates/ContentTypeList", {
-                parentLink: selectionData.contentLink,
-                contentLink: this.contentLink,
+                parentLink: selectionData.parentLink,
+                contentLink: selectionData.contentLink,
                 templatesRoot: this.templatesRoot
             });
         },


### PR DESCRIPTION
The system remembered the first item atempted to create a template on, and used that for all other atempts to create from template. Resulting in filtering based on where creation should be not working as intended after the first.

The creation was also based on the parrent page of the selected page, which meant that when you rightclicked on a page on level 1 you would be getting template sugestions based on level 0.
