### PR TITLE
Gets the content asset folder for the page to store newly created blocks.

### DIFF
--- a/src/episervertemplating/modules/_protected/InstantTemplates/InstantTemplatesStore.cs
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/InstantTemplatesStore.cs
@@ -75,8 +75,24 @@ namespace EPiServer.InstantTemplates
 
         public RestResult Post(string templateLink, string parentLink, string name)
         {
-            var contentLink = this._contentRepository.Copy(new ContentReference(templateLink),
-                new ContentReference(parentLink), AccessLevel.Edit, AccessLevel.Edit, false);
+            var templateBlockData = this._contentRepository.Get<BlockData>(new ContentReference(templateLink));
+
+            ContentReference contentLink;
+
+            if (templateBlockData != null)
+            {
+                var assetsFolderForPage = ServiceLocator.Current
+                    .GetInstance<ContentAssetHelper>()
+                    .GetOrCreateAssetFolder(new ContentReference(parentLink));
+
+                contentLink = this._contentRepository.Copy(new ContentReference(templateLink),
+                    assetsFolderForPage.ContentLink, AccessLevel.Edit, AccessLevel.Edit, false);
+            }
+            else
+            {
+                contentLink = this._contentRepository.Copy(new ContentReference(templateLink),
+                    new ContentReference(parentLink), AccessLevel.Edit, AccessLevel.Edit, false);
+            }
 
             var temp = this._contentRepository.Get<ContentData>(contentLink).CreateWritableClone();
 


### PR DESCRIPTION
When creating a block for a page from a template, using the 'New from Template', this will get the content asset folder for the page in question and copy the block there instead. Previously this appeared to be copying the block to underneath the page, which after editing seemed to just disappear. 