### PR TITLE
Localize add-on texts to English, Norwegian and Swedish.

### DIFF
--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
@@ -17,9 +17,12 @@
     "epi/dependency",
 
     // Resources
-    "epi/i18n!epi-cms/nls/"
+    "epi/i18n!epi-cms/nls/",
 
-], function (declare, lang, array, domStyle, template, topic, dojo, _TemplatedMixin, _LayoutWidget, ContentType, keys, _KeyNavContainer, dependency, customLocalization) {
+    //Helpers
+    "instantTemplates/helpers"
+
+], function (declare, lang, array, domStyle, template, topic, dojo, _TemplatedMixin, _LayoutWidget, ContentType, keys, _KeyNavContainer, dependency, customLocalization, helpers) {
 
     return declare([_LayoutWidget, _TemplatedMixin, _KeyNavContainer], {
         // summary:
@@ -118,8 +121,7 @@
             topic.publish("/epi/shell/action/changeview", "instantTemplates/CreateContentView", null, {
                 parent: this.parentLink,
                 contentLink: item.contentLink,
-                headingText: customLocalization.episerver.cms.labels.newinstanttemplate != null ?
-                             customLocalization.episerver.cms.labels.newinstanttemplate : "New Instant Template",
+                headingText: helpers.translate(customLocalization.episerver.cms.labels.newinstanttemplate, "New Instant Template"),
                 templateName: item.name
             });
         },

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeGroup.js
@@ -14,9 +14,12 @@
     "dojo/keys",
     "dijit/_KeyNavContainer",
 
-    "epi/dependency"
+    "epi/dependency",
 
-], function (declare, lang, array, domStyle, template, topic, dojo, _TemplatedMixin, _LayoutWidget, ContentType, keys, _KeyNavContainer, dependency) {
+    // Resources
+    "epi/i18n!epi-cms/nls/"
+
+], function (declare, lang, array, domStyle, template, topic, dojo, _TemplatedMixin, _LayoutWidget, ContentType, keys, _KeyNavContainer, dependency, customLocalization) {
 
     return declare([_LayoutWidget, _TemplatedMixin, _KeyNavContainer], {
         // summary:
@@ -115,7 +118,8 @@
             topic.publish("/epi/shell/action/changeview", "instantTemplates/CreateContentView", null, {
                 parent: this.parentLink,
                 contentLink: item.contentLink,
-                headingText: "New Instant Template",
+                headingText: customLocalization.episerver.cms.labels.newinstanttemplate != null ?
+                             customLocalization.episerver.cms.labels.newinstanttemplate : "New Instant Template",
                 templateName: item.name
             });
         },

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
@@ -18,7 +18,9 @@
     "epi/shell/TypeDescriptorManager",
     "./ContentTypeGroup",
  //Resources
-    "epi/i18n!epi-cms/nls/"
+    "epi/i18n!epi-cms/nls/",
+//Helpers
+    "instantTemplates/helpers"
 ],
 
 function (
@@ -40,7 +42,9 @@ function (
     TypeDescriptorManager,
     ContentTypeGroup,
 //Resources
-    customLocalization
+    customLocalization,
+//Helpers
+    helpers
 ) {
 
     return declare([_LayoutWidget], {
@@ -72,8 +76,7 @@ function (
             var suggested = new ContentTypeGroup({templatesRoot: this.templatesRoot, parentLink: this.parentLink});
 
             domClass.add(suggested.titleNode, "epi-ribbonHeaderSpecial");
-            const title = customLocalization.episerver.cms.labels.availabletemplates != null ?
-                          customLocalization.episerver.cms.labels.availabletemplates : "Available Instant Templates"
+            const title = helpers.translate(customLocalization.episerver.cms.labels.availabletemplates, "Available Instant Templates");
             suggested.set("title", title);
             suggested.set("templatesRoot", this.templatesRoot);
             suggested.setVisibility(true);

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/ContentTypeList.js
@@ -16,7 +16,9 @@
 // epi
     "epi/dependency",
     "epi/shell/TypeDescriptorManager",
-    "./ContentTypeGroup"
+    "./ContentTypeGroup",
+ //Resources
+    "epi/i18n!epi-cms/nls/"
 ],
 
 function (
@@ -36,7 +38,9 @@ function (
 // epi
     dependency,
     TypeDescriptorManager,
-    ContentTypeGroup
+    ContentTypeGroup,
+//Resources
+    customLocalization
 ) {
 
     return declare([_LayoutWidget], {
@@ -68,7 +72,9 @@ function (
             var suggested = new ContentTypeGroup({templatesRoot: this.templatesRoot, parentLink: this.parentLink});
 
             domClass.add(suggested.titleNode, "epi-ribbonHeaderSpecial");
-            suggested.set("title", "Available Instant Templates");
+            const title = customLocalization.episerver.cms.labels.availabletemplates != null ?
+                          customLocalization.episerver.cms.labels.availabletemplates : "Available Instant Templates"
+            suggested.set("title", title);
             suggested.set("templatesRoot", this.templatesRoot);
             suggested.setVisibility(true);
             this.addChild(suggested);

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/CreateContentView.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/CreateContentView.js
@@ -271,6 +271,7 @@ function (
                     if(this.nameTextBox) {
                         this.nameTextBox.focus();
                         this.nameTextBox.textbox.select();
+                        this.nameTextBox.set("value", "");
                     }
 
                 }), function(err) {

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/Helpers.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/Helpers.js
@@ -1,0 +1,11 @@
+﻿define("instantTemplates/helpers", [ ],
+    function () {
+        return {
+            translate: function (translation, fallback) {
+                if (translation != null)
+                    return translation;
+
+                return fallback;
+            },
+        };
+    });

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentSelectionCommand.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentSelectionCommand.js
@@ -1,12 +1,16 @@
 ﻿define([
     "dojo/_base/declare",
     "dojo/topic",
+    //Resources
+    "epi/i18n!epi-cms/nls/",
     // Parent class and mixins
     "epi/shell/command/_Command",
     "epi/shell/command/_SelectionCommandMixin"
 ], function (
     declare,
     topic,
+    //Resources
+    customLocalization,
     // Parent class and mixins
     _Command,
     _SelectionCommandMixin
@@ -16,7 +20,8 @@
 
         iconClass: "epi-iconPackage epi-icon--inverted",
 
-        label: "New from Template",
+        label: customLocalization.episerver.cms.command.newtemplate != null ?
+               customLocalization.episerver.cms.command.newtemplate : "New from template",
 
         _execute: function () {
             var selectionData = this.get("selectionData");

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentSelectionCommand.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentSelectionCommand.js
@@ -5,7 +5,9 @@
     "epi/i18n!epi-cms/nls/",
     // Parent class and mixins
     "epi/shell/command/_Command",
-    "epi/shell/command/_SelectionCommandMixin"
+    "epi/shell/command/_SelectionCommandMixin",
+    //Helpers
+    "instantTemplates/helpers"
 ], function (
     declare,
     topic,
@@ -13,15 +15,15 @@
     customLocalization,
     // Parent class and mixins
     _Command,
-    _SelectionCommandMixin
+    _SelectionCommandMixin,
+    helpers
 ) {
 
     return declare([_Command, _SelectionCommandMixin], {
 
         iconClass: "epi-iconPackage epi-icon--inverted",
 
-        label: customLocalization.episerver.cms.command.newtemplate != null ?
-               customLocalization.episerver.cms.command.newtemplate : "New from template",
+        label: helpers.translate(customLocalization.episerver.cms.command.newtemplate, "New from template"),
 
         _execute: function () {
             var selectionData = this.get("selectionData");

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentTypesCommand.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentTypesCommand.js
@@ -6,7 +6,9 @@
     "epi/i18n!epi-cms/nls/episerver.cms.contentediting.toolbar.buttons.compare",
     // Parent class and mixins
     "epi/shell/command/_Command",
-    "epi-cms/_ContentContextMixin"
+    "epi-cms/_ContentContextMixin",
+    //Helpers
+    "instantTemplates/helpers"
 ], function (
     declare,
     topic,
@@ -15,7 +17,8 @@
     localizations,
     // Parent class and mixins
     _Command,
-    _ContentContextMixin
+    _ContentContextMixin,
+    helpers
 ) {
 
     return declare([_Command, _ContentContextMixin], {
@@ -29,8 +32,7 @@
         //      The CSS class which represents the icon to be used in visual elements.
         iconClass: "epi-iconPackage epi-icon--inverted",
 
-        label: customLocalization.episerver.cms.command.newtemplate != null ? 
-               customLocalization.episerver.cms.command.newtemplate : "New from template",
+        label: helpers.translate(customLocalization.episerver.cms.command.newtemplate, "New from template"),
 
         // canExecute: [readonly] Boolean
         //      Flag which indicates whether this command is able to be executed.

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentTypesCommand.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplateContentTypesCommand.js
@@ -2,6 +2,7 @@
     "dojo/_base/declare",
     "dojo/topic",
     // Resources
+    "epi/i18n!epi-cms/nls/",
     "epi/i18n!epi-cms/nls/episerver.cms.contentediting.toolbar.buttons.compare",
     // Parent class and mixins
     "epi/shell/command/_Command",
@@ -10,6 +11,7 @@
     declare,
     topic,
     // Resources
+    customLocalization,
     localizations,
     // Parent class and mixins
     _Command,
@@ -27,7 +29,8 @@
         //      The CSS class which represents the icon to be used in visual elements.
         iconClass: "epi-iconPackage epi-icon--inverted",
 
-        label: "New from Template",
+        label: customLocalization.episerver.cms.command.newtemplate != null ? 
+               customLocalization.episerver.cms.command.newtemplate : "New from template",
 
         // canExecute: [readonly] Boolean
         //      Flag which indicates whether this command is able to be executed.

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplatesWidget.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplatesWidget.js
@@ -10,7 +10,9 @@
     "dojo/on",
     "epi-cms/asset/HierarchicalList",
     // Resources
-    "epi/i18n!epi-cms/nls/"
+    "epi/i18n!epi-cms/nls/",
+    //Helpers
+    "instantTemplates/helpers"
 ],
     function (
         // dojo
@@ -23,17 +25,16 @@
         domClass,
         on,
         HierarchicalList,
-        customLocalization
+        customLocalization,
+        helpers
     ) {
         return declare([HierarchicalList],
         {
             showCreateContentArea: false,
 
             noDataMessages: { 
-                multiple: customLocalization.episerver.cms.messages.nodatamultiple != null ?
-                          customLocalization.episerver.cms.messages.nodatamultiple : "These folders does not contain any templates", 
-                single: customLocalization.episerver.cms.messages.nodatasingle != null ?
-                        customLocalization.episerver.cms.messages.nodatasingle : "This folder does not contain any templates"
+                multiple: helpers.translate(customLocalization.episerver.cms.messages.nodatamultiple, "These folders does not contain any templates"), 
+                single: helpers.translate(customLocalization.episerver.cms.messages.nodatasingle, "This folder does not contain any templates")
             } 
         });
     });

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplatesWidget.js
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/TemplatesWidget.js
@@ -8,7 +8,9 @@
     "dojo/dom-geometry",
     "dojo/dom-class",
     "dojo/on",
-    "epi-cms/asset/HierarchicalList"
+    "epi-cms/asset/HierarchicalList",
+    // Resources
+    "epi/i18n!epi-cms/nls/"
 ],
     function (
         // dojo
@@ -20,14 +22,18 @@
         domGeometry,
         domClass,
         on,
-        HierarchicalList) {
+        HierarchicalList,
+        customLocalization
+    ) {
         return declare([HierarchicalList],
         {
             showCreateContentArea: false,
 
             noDataMessages: { 
-                    multiple: "These folders does not contain any templates", 
-                    single: "This folder does not contain any templates"
-                } 
+                multiple: customLocalization.episerver.cms.messages.nodatamultiple != null ?
+                          customLocalization.episerver.cms.messages.nodatamultiple : "These folders does not contain any templates", 
+                single: customLocalization.episerver.cms.messages.nodatasingle != null ?
+                        customLocalization.episerver.cms.messages.nodatasingle : "This folder does not contain any templates"
+            } 
         });
     });

--- a/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/templates/ContentTypeGroup.html
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/ClientResources/Scripts/templates/ContentTypeGroup.html
@@ -1,4 +1,4 @@
-﻿<div class="epi-listingContainer" data-dojo-attach-point="focusNode" tabIndex="${tabIndex}">
+﻿<div class="epi-listingContainer" data-dojo-attach-point="focusNode" tabIndex="${tabIndex}" style="overflow: auto; height: inherit;">
     <h2 data-dojo-attach-point="titleNode" class="epi-ribbonHeader"></h2>
     <ul data-dojo-attach-point="containerNode" class="epi-advancedListing"></ul>
 </div>

--- a/src/episervertemplating/modules/_protected/InstantTemplates/InstantTemplates.csproj
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/InstantTemplates.csproj
@@ -231,6 +231,7 @@
     <Content Include="ClientResources\Scripts\ContentTypeGroup.js" />
     <Content Include="ClientResources\Scripts\ContentTypeList.js" />
     <Content Include="ClientResources\Scripts\ContextMenuCommandProvider.js" />
+    <Content Include="ClientResources\Scripts\Helpers.js" />
     <Content Include="ClientResources\Scripts\TemplateContentSelectionCommand.js" />
     <Content Include="ClientResources\Scripts\TemplateContentTypesCommand.js" />
     <Content Include="ClientResources\Scripts\TemplatesWidget.js" />

--- a/src/episervertemplating/modules/_protected/InstantTemplates/InstantTemplates.csproj
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/InstantTemplates.csproj
@@ -236,6 +236,7 @@
     <Content Include="ClientResources\Scripts\TemplatesWidget.js" />
     <Content Include="ClientResources\Scripts\templates\ContentType.html" />
     <Content Include="ClientResources\Scripts\templates\ContentTypeGroup.html" />
+    <EmbeddedResource Include="lang\CustomTranslations.xml" />
     <Content Include="web.config.install.xdt" />
     <Content Include="web.config.uninstall.xdt" />
     <None Include="module.config">

--- a/src/episervertemplating/modules/_protected/InstantTemplates/TemplatesMainNavigationComponent.cs
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/TemplatesMainNavigationComponent.cs
@@ -7,13 +7,14 @@ namespace EPiServer.InstantTemplates
     [Component]
     public class TemplatesMainNavigationComponent : ComponentDefinitionBase
     {
+
         public TemplatesMainNavigationComponent() : base("instantTemplates/templatesWidget")
         {
-            Categories = new string[] { "content" };
-            //LanguagePath = "/episerver/cms/components/templates";
-            Title = "Templates";
-            SortOrder = 102;
             PlugInAreas = new string[] { PlugInArea.AssetsDefaultGroup };
+            Categories = new string[] { "content" };
+            SortOrder = 102;
+            LanguagePath = "/episerver/cms/views/templates";
+            Title = "Templates";
             Settings.Add(new Setting("repositoryKey", TemplatesRepositoryDescriptor.RepositoryKey));
             Description = "Allows editors to easily create their own templates from within EPiServer edit mode.";
         }

--- a/src/episervertemplating/modules/_protected/InstantTemplates/lang/CustomTranslations.xml
+++ b/src/episervertemplating/modules/_protected/InstantTemplates/lang/CustomTranslations.xml
@@ -1,0 +1,83 @@
+﻿<languages>
+  <language id="en" name="English">
+    <episerver>
+      <cms>
+        <command>
+          <newtemplate>New from Template</newtemplate>
+        </command>
+        <labels>
+          <availabletemplates>Available Templates</availabletemplates>
+          <newinstanttemplate>New Instant Template</newinstanttemplate>
+        </labels>
+        <messages>
+          <nodatamultiple>
+            These folders does not contain any templates
+          </nodatamultiple>
+          <nodatasingle>
+            This folder does not contain any templates
+          </nodatasingle>
+        </messages>
+        <views>
+          <templates>
+            <title>Templates</title>
+            <description>Allows editors to easily create their own templates from within EPiServer edit mode.</description>
+          </templates>
+        </views>
+      </cms>
+    </episerver>
+  </language>
+  <language id="no" name="Norwegian">
+    <episerver>
+      <cms>
+        <command>
+          <newtemplate>Nytt fra mal</newtemplate>
+        </command>
+        <labels>
+          <availabletemplates>Tilgjengelige maler</availabletemplates>
+          <newinstanttemplate>Ny øyeblikkelig mal</newinstanttemplate>
+        </labels>
+        <messages>
+          <nodatamultiple>
+            Disse mappene inneholder ingen maler
+          </nodatamultiple>
+          <nodatasingle>
+            Denne mappen inneholder ingen maler
+          </nodatasingle>
+        </messages>
+        <views>
+          <templates>
+            <title>Maler</title>
+            <description>Lar redaktører enkelt lage egne maler fra EPiServer redigeringsmodus.</description>
+          </templates>
+        </views>
+      </cms>
+    </episerver>
+  </language>
+  <language id="sv" name="Swedish">
+    <episerver>
+      <cms>
+        <command>
+          <newtemplate>Nytt från mall</newtemplate>
+        </command>
+        <labels>
+          <availabletemplates>Tillgängliga mallar</availabletemplates>
+          <newinstanttemplate>Ny direktmall</newinstanttemplate>
+        </labels>
+        <messages>
+          <nodatamultiple>
+            Dessa mappar innehåller inga mallar
+          </nodatamultiple>
+          <nodatasingle>
+            Den här mappen innehåller inga mallar
+          </nodatasingle>
+        </messages>
+        <views>
+          <templates>
+            <title>Mallar</title>
+            <description>Låter redaktörer enkelt skapa sina egna mallar från EPiServer-redigeringsläget.</description>
+          </templates>
+        </views>
+      </cms>
+    </episerver>
+  </language>
+</languages>


### PR DESCRIPTION
Localize add-on texts to English, Norwegian and Swedish. (resolves issue #4)
Clear new instant template name on view rendering. (resolves issue #5)