### PR TITLE
Change sort order so the intant template repository descriptor comes …

### DIFF
--- a/src/TemplatesRepositoryDescriptor.cs
+++ b/src/TemplatesRepositoryDescriptor.cs
@@ -76,5 +76,7 @@ namespace EPiServer.InstantTemplates
         }
 
         public bool EnableContextualContent { get { return true; } }
+
+        public override int SortOrder => 10000;
     }
 }


### PR DESCRIPTION
Problem is caused that first UI descriptor is used when multiple UI descriptors are found for the containing type. By changing the sort order the instant templates UI descriptor is used as last.

![image](https://user-images.githubusercontent.com/2243586/82800927-c830dc00-9e7c-11ea-8777-a44e6961483f.png)
